### PR TITLE
CI: install full mono to get sdk2

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update -y -qq
-          sudo apt -y install mono-mcs wget zip
+          sudo apt -y install mono-complete mono-mcs wget zip
 
       - name: Build ${{ matrix.mode }}
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,7 +10,7 @@ jobs:
   test-ubuntu:
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
+        os: [ubuntu-22.04, ubuntu-24.04]
 
     name: test-${{ matrix.os }}
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
If mono falls back to 4.x, because 2.0 is not available, it'll end up using features that are not supported on .net <= 3.5.